### PR TITLE
ci(phase-0): prep run/ with EULA + minimal server.properties before smoke test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,16 +32,45 @@ jobs:
       - name: Build
         run: .\gradlew.bat --no-daemon build
 
-      - name: Server smoke test (90s)
+      - name: Prep run directory (EULA + server.properties)
         shell: pwsh
         run: |
-          $p = Start-Process -FilePath ".\gradlew.bat" -ArgumentList "--no-daemon runServer" -PassThru -WindowStyle Hidden
-          Start-Sleep -Seconds 90
-          if (-not $p.HasExited) { Stop-Process -Id $p.Id -Force }
-          if (Test-Path ".\run\logs\latest.log") {
-            $log = Get-Content ".\run\logs\latest.log" -Raw
-            if ($log -match "Done \(") { exit 0 } else { Get-Content ".\run\logs\latest.log" | Select-Object -Last 200; exit 1 }
-          } else { exit 1 }
+          New-Item -ItemType Directory -Force -Path ".\run" | Out-Null
+          # Accept EULA so server can start
+          Set-Content -NoNewline -Path ".\run\eula.txt" -Value "eula=true`r`n"
+          # Minimal server.properties (avoid NoSuchFileException)
+          @"
+#Minecraft server properties
+  motd=SentinelCore CI Smoke
+  server-port=25565
+  max-players=1
+  enable-command-block=false
+  online-mode=false
+  difficulty=easy
+  gamemode=survival
+  "@ | Set-Content -Path ".\run\server.properties" -NoNewline
+
+- name: Server smoke test (90s)
+  shell: pwsh
+  run: |
+    $p = Start-Process -FilePath ".\gradlew.bat" -ArgumentList "--no-daemon runServer" -PassThru -WindowStyle Hidden
+    Start-Sleep -Seconds 90
+    if (-not $p.HasExited) { Stop-Process -Id $p.Id -Force }
+    if (Test-Path ".\run\logs\latest.log") {
+      $log = Get-Content ".\run\logs\latest.log" -Raw
+      if ($log -match "Done \(") {
+        Write-Host "✅ Server reached 'Done'."
+        exit 0
+      } else {
+        Write-Host "❌ Server didn’t reach 'Done' within 90s. Tail follows:"
+        Get-Content ".\run\logs\latest.log" | Select-Object -Last 200
+        exit 1
+      }
+    } else {
+      Write-Host "❌ No server log found at .\run\logs\latest.log."
+      exit 1
+    }
+
 
       - name: Upload build artifacts
         if: success()

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,6 @@ jobs:
       - name: Build
         run: .\gradlew.bat --no-daemon build
 
-      # Short server boot to catch obvious misconfig; we don't keep it running.
       - name: Server smoke test (90s)
         shell: pwsh
         run: |
@@ -41,19 +40,8 @@ jobs:
           if (-not $p.HasExited) { Stop-Process -Id $p.Id -Force }
           if (Test-Path ".\run\logs\latest.log") {
             $log = Get-Content ".\run\logs\latest.log" -Raw
-            if ($log -match "Done \(") {
-              Write-Host "✅ Server reached 'Done' state."
-              exit 0
-            } else {
-              Write-Host "❌ Server didn’t reach 'Done' within 90s."
-              Write-Host "------ last 200 lines ------"
-              Get-Content ".\run\logs\latest.log" | Select-Object -Last 200
-              exit 1
-            }
-          } else {
-            Write-Host "❌ No server log found at .\run\logs\latest.log."
-            exit 1
-          }
+            if ($log -match "Done \(") { exit 0 } else { Get-Content ".\run\logs\latest.log" | Select-Object -Last 200; exit 1 }
+          } else { exit 1 }
 
       - name: Upload build artifacts
         if: success()


### PR DESCRIPTION
This PR fixes the CI smoke test failing on missing eula.txt and server.properties.
- Adds pre-step to create run/eula.txt (eula=true)
- Adds minimal server.properties for headless CI
- Keeps 90s smoke test check for "Done ("
