### PR TITLE
Feature/phase 0 issue 1 init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ out/
 bin/
 .vscode/
 logs/
+run/
+crash-reports/
+*.log

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ dependencies {
 
     // LuckPerms: compile against API; runtime jar goes in the server /mods folder
     compileOnly "net.luckperms:api:${project.luckperms_api_version}"
+
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.17.2")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.2")
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,38 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.2")
 }
 
+// Auto-create EULA and server.properties before runServer
+tasks.named("runServer") { t ->
+    doFirst {
+        // Prefer the task's workingDir if Loom sets it; otherwise use project directory / run
+        File runDir = (t.hasProperty('workingDir') && t.workingDir instanceof File && t.workingDir)
+                ? t.workingDir as File
+                : layout.projectDirectory.dir("run").asFile
+
+        if (!runDir.exists()) {
+            runDir.mkdirs()
+        }
+
+        File eula = new File(runDir, "eula.txt")
+        if (!eula.exists()) {
+            eula.text = "eula=true" + System.lineSeparator()
+            println "Created ${eula.absolutePath}"
+        }
+
+        File props = new File(runDir, "server.properties")
+        if (!props.exists()) {
+            props.text = """#Minecraft server properties
+motd=SentinelCore Dev
+server-port=25565
+online-mode=false
+max-players=20
+"""
+            println "Created ${props.absolutePath}"
+        }
+    }
+}
+
+
 processResources {
     inputs.property "version",           project.version
     inputs.property "minecraft_version", project.minecraft_version

--- a/docs/docs.config.sample.yaml
+++ b/docs/docs.config.sample.yaml
@@ -1,0 +1,9 @@
+featureFlags:
+  exampleFlag: false
+
+logging:
+  audit: true
+  perm: true
+  move: true
+  modmode: true
+  spawn: true

--- a/eula.txt
+++ b/eula.txt
@@ -1,0 +1,1 @@
+eula=true

--- a/server.properties
+++ b/server.properties
@@ -1,0 +1,5 @@
+#Minecraft server properties
+motd=SentinelCore Dev
+server-port=25565
+online-mode=false
+max-players=20

--- a/src/main/java/org/github/shatterz/sentinelcore/SentinelCore.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/SentinelCore.java
@@ -1,16 +1,30 @@
 package org.github.shatterz.sentinelcore;
 
 import net.fabricmc.api.ModInitializer;
+import org.github.shatterz.sentinelcore.config.ConfigManager;
+import org.github.shatterz.sentinelcore.flags.FeatureFlagRegistry;
+import org.github.shatterz.sentinelcore.log.SentinelLogger;
+import org.github.shatterz.sentinelcore.log.SentinelCategories;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class SentinelCore implements ModInitializer {
-  public static final String MOD_ID = "sentinelcore";
-  public static final Logger LOGGER = LoggerFactory.getLogger("SentinelCore");
+public final class SentinelCore implements ModInitializer {
+    public static final String MOD_ID = "sentinelcore";
 
-  @Override
-  public void onInitialize() {
-    LOGGER.info("[SentinelCore] Initializing base systems...");
-    // Phase 1+: PermissionMgr.init(), Config.load(), etc.
-  }
+    @Override
+    public void onInitialize() {
+        Logger log = SentinelLogger.root();
+        log.info("[SentinelCore] Initializing base systems...");
+
+        // config + flags (hot-reload is inside ConfigManager; FeatureFlagRegistry wires a callback)
+        FeatureFlagRegistry.wireReload();
+
+        // category demo logs (will respect on/off later if you add level filtering)
+        SentinelLogger.cat(SentinelCategories.AUDIT).info("Audit logging ready.");
+        SentinelLogger.cat(SentinelCategories.PERM).info("Permission logging ready.");
+        SentinelLogger.cat(SentinelCategories.MOVE).info("Movement logging ready.");
+        SentinelLogger.cat(SentinelCategories.MODMODE).info("ModMode logging ready.");
+        SentinelLogger.cat(SentinelCategories.SPAWN).info("Spawn logging ready.");
+
+        log.info("[SentinelCore] Initialization complete.");
+    }
 }

--- a/src/main/java/org/github/shatterz/sentinelcore/SentinelCore.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/SentinelCore.java
@@ -1,30 +1,29 @@
 package org.github.shatterz.sentinelcore;
 
 import net.fabricmc.api.ModInitializer;
-import org.github.shatterz.sentinelcore.config.ConfigManager;
 import org.github.shatterz.sentinelcore.flags.FeatureFlagRegistry;
-import org.github.shatterz.sentinelcore.log.SentinelLogger;
 import org.github.shatterz.sentinelcore.log.SentinelCategories;
+import org.github.shatterz.sentinelcore.log.SentinelLogger;
 import org.slf4j.Logger;
 
 public final class SentinelCore implements ModInitializer {
-    public static final String MOD_ID = "sentinelcore";
+  public static final String MOD_ID = "sentinelcore";
 
-    @Override
-    public void onInitialize() {
-        Logger log = SentinelLogger.root();
-        log.info("[SentinelCore] Initializing base systems...");
+  @Override
+  public void onInitialize() {
+    Logger log = SentinelLogger.root();
+    log.info("[SentinelCore] Initializing base systems...");
 
-        // config + flags (hot-reload is inside ConfigManager; FeatureFlagRegistry wires a callback)
-        FeatureFlagRegistry.wireReload();
+    // config + flags (hot-reload is inside ConfigManager; FeatureFlagRegistry wires a callback)
+    FeatureFlagRegistry.wireReload();
 
-        // category demo logs (will respect on/off later if you add level filtering)
-        SentinelLogger.cat(SentinelCategories.AUDIT).info("Audit logging ready.");
-        SentinelLogger.cat(SentinelCategories.PERM).info("Permission logging ready.");
-        SentinelLogger.cat(SentinelCategories.MOVE).info("Movement logging ready.");
-        SentinelLogger.cat(SentinelCategories.MODMODE).info("ModMode logging ready.");
-        SentinelLogger.cat(SentinelCategories.SPAWN).info("Spawn logging ready.");
+    // category demo logs (will respect on/off later if you add level filtering)
+    SentinelLogger.cat(SentinelCategories.AUDIT).info("Audit logging ready.");
+    SentinelLogger.cat(SentinelCategories.PERM).info("Permission logging ready.");
+    SentinelLogger.cat(SentinelCategories.MOVE).info("Movement logging ready.");
+    SentinelLogger.cat(SentinelCategories.MODMODE).info("ModMode logging ready.");
+    SentinelLogger.cat(SentinelCategories.SPAWN).info("Spawn logging ready.");
 
-        log.info("[SentinelCore] Initialization complete.");
-    }
+    log.info("[SentinelCore] Initialization complete.");
+  }
 }

--- a/src/main/java/org/github/shatterz/sentinelcore/config/ConfigManager.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/config/ConfigManager.java
@@ -15,54 +15,54 @@ import java.io.OutputStream;
 import java.util.Locale;
 
 public final class ConfigManager {
-  private static final Logger LOG = LoggerFactory.getLogger("SentinelCore/Config");
-  private static final ObjectMapper YAML = new ObjectMapper(new YAMLFactory());
-  private static final ObjectMapper JSON = new ObjectMapper();
+    private static final Logger LOG = LoggerFactory.getLogger("SentinelCore/Config");
+    private static final ObjectMapper YAML = new ObjectMapper(new YAMLFactory());
+    private static final ObjectMapper JSON = new ObjectMapper();
 
-  private static final String DIR_NAME = "sentinelcore";
-  private static final String YAML_NAME = "config.yaml";
-  private static final String JSON_NAME = "config.json";
+    private static final String DIR_NAME = "sentinelcore";
+    private static final String YAML_NAME = "config.yaml";
+    private static final String JSON_NAME = "config.json";
 
-  private static Path configDir() {
-    return FabricLoader.getInstance().getConfigDir().resolve(DIR_NAME);
-  }
-
-  private static Path yamlPath() {
-    return configDir().resolve(YAML_NAME);
-  }
-
-  private static Path jsonPath() {
-    return configDir().resolve(JSON_NAME);
-  }
-
-  private static volatile CoreConfig CURRENT = CoreConfig.defaults();
-
-  public static CoreConfig get() {
-    return CURRENT;
-  }
-
-  public static void init(Consumer<CoreConfig> onReload) {
-    try {
-      Files.createDirectories(configDir());
-      Path yml = yamlPath();
-      Path json = jsonPath();
-      if (!Files.exists(yml) && !Files.exists(json)) {
-        // write defaults to YAML
-        saveYAML(CoreConfig.defaults());
-        LOG.info("Created default config at {}", yml.toAbsolutePath());
-      }
-      CURRENT = load();
-      LOG.info("Loaded config: {} featureFlags={}", fileInUse(), CURRENT.featureFlags.keySet());
-      startWatcher(onReload);
-    } catch (IOException e) {
-      LOG.error("Failed to init config, using defaults", e);
-      CURRENT = CoreConfig.defaults();
+    private static Path configDir() {
+        return FabricLoader.getInstance().getConfigDir().resolve(DIR_NAME);
     }
-  }
 
-  public static Path fileInUse() {
-    return Files.exists(yamlPath()) ? yamlPath() : jsonPath();
-  }
+    private static Path yamlPath() {
+        return configDir().resolve(YAML_NAME);
+    }
+
+    private static Path jsonPath() {
+        return configDir().resolve(JSON_NAME);
+    }
+
+    private static volatile CoreConfig CURRENT = CoreConfig.defaults();
+
+    public static CoreConfig get() {
+        return CURRENT;
+    }
+
+    public static void init(Consumer<CoreConfig> onReload) {
+        try {
+            Files.createDirectories(configDir());
+            Path yml = yamlPath();
+            Path json = jsonPath();
+            if (!Files.exists(yml) && !Files.exists(json)) {
+                // write defaults to YAML
+                saveYAML(CoreConfig.defaults());
+                LOG.info("Created default config at {}", yml.toAbsolutePath());
+            }
+            CURRENT = load();
+            LOG.info("Loaded config: {} featureFlags={}", fileInUse(), CURRENT.featureFlags.keySet());
+            startWatcher(onReload);
+        } catch (IOException e) {
+            LOG.error("Failed to init config, using defaults", e);
+            CURRENT = CoreConfig.defaults();
+        }
+    }
+
+    public static Path fileInUse() {
+        return Files.exists(yamlPath()) ? yamlPath() : jsonPath();
+    }
 
     public static CoreConfig load() throws IOException {
         Path file = fileInUse();
@@ -85,44 +85,48 @@ public final class ConfigManager {
     }
 
 
-  // naive debounced watcher (single-threaded)
-  private static void startWatcher(Consumer<CoreConfig> onReload) {
-      var executor = Executors.newSingleThreadExecutor(r -> {
-          Thread t = new Thread(r, "SentinelCore-ConfigWatcher");
-          t.setDaemon(true);
-          return t;
-      });
+    // naive debounced watcher (single-threaded)
+    private static void startWatcher(Consumer<CoreConfig> onReload) {
+        var executor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "SentinelCore-ConfigWatcher");
+            t.setDaemon(true);
+            return t;
+        });
 
-      executor.submit(() -> {
-          try (WatchService ws = FileSystems.getDefault().newWatchService()) {
-              configDir().register(ws,
-                      StandardWatchEventKinds.ENTRY_MODIFY,
-                      StandardWatchEventKinds.ENTRY_CREATE);
-              LOG.info("Watching {} for changes", configDir().toAbsolutePath());
+        executor.submit(() -> {
+            try (WatchService ws = FileSystems.getDefault().newWatchService()) {
+                configDir().register(ws,
+                        StandardWatchEventKinds.ENTRY_MODIFY,
+                        StandardWatchEventKinds.ENTRY_CREATE);
+                LOG.info("Watching {} for changes", configDir().toAbsolutePath());
 
-              while (!Thread.currentThread().isInterrupted()) {
-                  WatchKey key = ws.take();
-                  boolean relevant = false;
-                  for (WatchEvent<?> ev : key.pollEvents()) {
-                      Path p = (Path) ev.context();
-                      String n = p.getFileName().toString();
-                      if (YAML_NAME.equals(n) || JSON_NAME.equals(n)) relevant = true;
-                  }
-                  key.reset();
-                  if (relevant) {
-                      TimeUnit.MILLISECONDS.sleep(250);
-                      try {
-                          CoreConfig newCfg = load();
-                          CURRENT = newCfg;
-                          LOG.info("Config reloaded from {}", fileInUse().toAbsolutePath());
-                          if (onReload != null) onReload.accept(newCfg);
-                      } catch (Exception ex) {
-                          LOG.error("Failed to reload config", ex);
-                      }
-                  }
-              }
-          } catch (Exception e) {
-              LOG.error("Config watcher stopped", e);
-          }
-      });
-  }
+                while (!Thread.currentThread().isInterrupted()) {
+                    WatchKey key = ws.take();
+                    boolean relevant = false;
+                    for (WatchEvent<?> ev : key.pollEvents()) {
+                        Path p = (Path) ev.context();
+                        String n = p.getFileName().toString();
+                        if (YAML_NAME.equals(n) || JSON_NAME.equals(n)) relevant = true;
+                    }
+                    key.reset();
+                    if (relevant) {
+                        TimeUnit.MILLISECONDS.sleep(250);
+                        try {
+                            CoreConfig newCfg = load();
+                            CURRENT = newCfg;
+                            LOG.info("Config reloaded from {}", fileInUse().toAbsolutePath());
+                            if (onReload != null) onReload.accept(newCfg);
+                        } catch (Exception ex) {
+                            LOG.error("Failed to reload config", ex);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                LOG.error("Config watcher stopped", e);
+            }
+        });
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            executor.shutdownNow();
+        }, "SentinelCore-ConfigWatcher-Shutdown"));
+    }
+}

--- a/src/main/java/org/github/shatterz/sentinelcore/config/ConfigManager.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/config/ConfigManager.java
@@ -14,6 +14,7 @@ import java.io.BufferedReader;
 import java.io.OutputStream;
 import java.util.Locale;
 
+
 public final class ConfigManager {
     private static final Logger LOG = LoggerFactory.getLogger("SentinelCore/Config");
     private static final ObjectMapper YAML = new ObjectMapper(new YAMLFactory());
@@ -78,7 +79,6 @@ public final class ConfigManager {
     }
 
     public static void saveYAML(CoreConfig cfg) throws IOException {
-        // Use try-with-resources so Qodana sees the stream is closed explicitly
         try (OutputStream out = Files.newOutputStream(yamlPath())) {
             YAML.writerWithDefaultPrettyPrinter().writeValue(out, cfg);
         }
@@ -98,6 +98,7 @@ public final class ConfigManager {
                 configDir().register(ws,
                         StandardWatchEventKinds.ENTRY_MODIFY,
                         StandardWatchEventKinds.ENTRY_CREATE);
+
                 LOG.info("Watching {} for changes", configDir().toAbsolutePath());
 
                 while (!Thread.currentThread().isInterrupted()) {
@@ -125,8 +126,8 @@ public final class ConfigManager {
                 LOG.error("Config watcher stopped", e);
             }
         });
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            executor.shutdownNow();
-        }, "SentinelCore-ConfigWatcher-Shutdown"));
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> executor.shutdownNow(),
+                "SentinelCore-ConfigWatcher-Shutdown"));
     }
 }

--- a/src/main/java/org/github/shatterz/sentinelcore/config/ConfigManager.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/config/ConfigManager.java
@@ -1,0 +1,108 @@
+package org.github.shatterz.sentinelcore.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import net.fabricmc.loader.api.FabricLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+public final class ConfigManager {
+    private static final Logger LOG = LoggerFactory.getLogger("SentinelCore/Config");
+    private static final ObjectMapper YAML = new ObjectMapper(new YAMLFactory());
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private static final String DIR_NAME = "sentinelcore";
+    private static final String YAML_NAME = "config.yaml";
+    private static final String JSON_NAME = "config.json";
+
+    private static Path configDir() {
+        return FabricLoader.getInstance().getConfigDir().resolve(DIR_NAME);
+    }
+    private static Path yamlPath(){ return configDir().resolve(YAML_NAME); }
+    private static Path jsonPath(){ return configDir().resolve(JSON_NAME); }
+
+    private static volatile CoreConfig CURRENT = CoreConfig.defaults();
+    public static CoreConfig get(){ return CURRENT; }
+
+    public static void init(Consumer<CoreConfig> onReload){
+        try {
+            Files.createDirectories(configDir());
+            Path yml = yamlPath();
+            Path json = jsonPath();
+            if (!Files.exists(yml) && !Files.exists(json)) {
+                // write defaults to YAML
+                saveYAML(CoreConfig.defaults());
+                LOG.info("Created default config at {}", yml.toAbsolutePath());
+            }
+            CURRENT = load();
+            LOG.info("Loaded config: {} featureFlags={}", fileInUse(), CURRENT.featureFlags.keySet());
+            startWatcher(onReload);
+        } catch (IOException e) {
+            LOG.error("Failed to init config, using defaults", e);
+            CURRENT = CoreConfig.defaults();
+        }
+    }
+
+    public static Path fileInUse(){
+        return Files.exists(yamlPath()) ? yamlPath() : jsonPath();
+    }
+
+    public static CoreConfig load() throws IOException {
+        Path file = fileInUse();
+        if (file.toString().endsWith(".json")) {
+            return JSON.readValue(Files.newBufferedReader(file), CoreConfig.class);
+        } else {
+            return YAML.readValue(Files.newBufferedReader(file), CoreConfig.class);
+        }
+    }
+
+    public static void saveYAML(CoreConfig cfg) throws IOException {
+        YAML.writerWithDefaultPrettyPrinter().writeValue(yamlPath().toFile(), cfg);
+    }
+
+    // naive debounced watcher (single-threaded)
+    private static void startWatcher(Consumer<CoreConfig> onReload) {
+        var executor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "SentinelCore-ConfigWatcher");
+            t.setDaemon(true);
+            return t;
+        });
+
+        executor.submit(() -> {
+            try (WatchService ws = FileSystems.getDefault().newWatchService()) {
+                configDir().register(ws, StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_CREATE);
+                LOG.info("Watching {} for changes", configDir().toAbsolutePath());
+                while (true) {
+                    WatchKey key = ws.take();
+                    boolean relevant = false;
+                    for (WatchEvent<?> ev : key.pollEvents()) {
+                        Path p = (Path) ev.context();
+                        String n = p.getFileName().toString();
+                        if (YAML_NAME.equals(n) || JSON_NAME.equals(n)) { relevant = true; }
+                    }
+                    key.reset();
+                    if (relevant) {
+                        // debounce
+                        TimeUnit.MILLISECONDS.sleep(250);
+                        try {
+                            CoreConfig newCfg = load();
+                            CURRENT = newCfg;
+                            LOG.info("Config reloaded from {}", fileInUse().toAbsolutePath());
+                            if (onReload != null) onReload.accept(newCfg);
+                        } catch (Exception ex) {
+                            LOG.error("Failed to reload config", ex);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                LOG.error("Config watcher stopped", e);
+            }
+        });
+    }
+}

--- a/src/main/java/org/github/shatterz/sentinelcore/config/CoreConfig.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/config/CoreConfig.java
@@ -1,0 +1,24 @@
+package org.github.shatterz.sentinelcore.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CoreConfig {
+    public Map<String, Boolean> featureFlags = new HashMap<>();
+    public Logging logging = new Logging();
+
+    public static class Logging {
+        // per-category on/off (you can extend to levels later)
+        public boolean audit = true;
+        public boolean perm = true;
+        public boolean move = true;
+        public boolean modmode = true;
+        public boolean spawn = true;
+    }
+
+    public static CoreConfig defaults(){
+        CoreConfig c = new CoreConfig();
+        c.featureFlags.put("exampleFlag", false);
+        return c;
+    }
+}

--- a/src/main/java/org/github/shatterz/sentinelcore/config/CoreConfig.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/config/CoreConfig.java
@@ -4,21 +4,21 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class CoreConfig {
-    public Map<String, Boolean> featureFlags = new HashMap<>();
-    public Logging logging = new Logging();
+  public Map<String, Boolean> featureFlags = new HashMap<>();
+  public Logging logging = new Logging();
 
-    public static class Logging {
-        // per-category on/off (you can extend to levels later)
-        public boolean audit = true;
-        public boolean perm = true;
-        public boolean move = true;
-        public boolean modmode = true;
-        public boolean spawn = true;
-    }
+  public static class Logging {
+    // per-category on/off (you can extend to levels later)
+    public boolean audit = true;
+    public boolean perm = true;
+    public boolean move = true;
+    public boolean modmode = true;
+    public boolean spawn = true;
+  }
 
-    public static CoreConfig defaults(){
-        CoreConfig c = new CoreConfig();
-        c.featureFlags.put("exampleFlag", false);
-        return c;
-    }
+  public static CoreConfig defaults() {
+    CoreConfig c = new CoreConfig();
+    c.featureFlags.put("exampleFlag", false);
+    return c;
+  }
 }

--- a/src/main/java/org/github/shatterz/sentinelcore/flags/FeatureFlagRegistry.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/flags/FeatureFlagRegistry.java
@@ -1,32 +1,31 @@
 package org.github.shatterz.sentinelcore.flags;
 
-import org.github.shatterz.sentinelcore.config.CoreConfig;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.github.shatterz.sentinelcore.config.ConfigManager;
+import org.github.shatterz.sentinelcore.config.CoreConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 public final class FeatureFlagRegistry {
-    private static final Logger LOG = LoggerFactory.getLogger("SentinelCore/Flags");
-    private static final Map<String, Boolean> FLAGS = new ConcurrentHashMap<>();
+  private static final Logger LOG = LoggerFactory.getLogger("SentinelCore/Flags");
+  private static final Map<String, Boolean> FLAGS = new ConcurrentHashMap<>();
 
-    private FeatureFlagRegistry(){}
+  private FeatureFlagRegistry() {}
 
-    public static void initFrom(CoreConfig cfg){
-        FLAGS.clear();
-        FLAGS.putAll(cfg.featureFlags);
-        LOG.info("Feature flags loaded: {}", FLAGS);
-    }
+  public static void initFrom(CoreConfig cfg) {
+    FLAGS.clear();
+    FLAGS.putAll(cfg.featureFlags);
+    LOG.info("Feature flags loaded: {}", FLAGS);
+  }
 
-    public static boolean isEnabled(String flag){
-        return FLAGS.getOrDefault(flag, false);
-    }
+  public static boolean isEnabled(String flag) {
+    return FLAGS.getOrDefault(flag, false);
+  }
 
-    // wire into config hot-reload
-    public static void wireReload(){
-        ConfigManager.init(FeatureFlagRegistry::initFrom);
-        initFrom(ConfigManager.get());
-    }
+  // wire into config hot-reload
+  public static void wireReload() {
+    ConfigManager.init(FeatureFlagRegistry::initFrom);
+    initFrom(ConfigManager.get());
+  }
 }

--- a/src/main/java/org/github/shatterz/sentinelcore/flags/FeatureFlagRegistry.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/flags/FeatureFlagRegistry.java
@@ -1,4 +1,32 @@
 package org.github.shatterz.sentinelcore.flags;
 
-public class FeatureFlagRegistry {
+import org.github.shatterz.sentinelcore.config.CoreConfig;
+import org.github.shatterz.sentinelcore.config.ConfigManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class FeatureFlagRegistry {
+    private static final Logger LOG = LoggerFactory.getLogger("SentinelCore/Flags");
+    private static final Map<String, Boolean> FLAGS = new ConcurrentHashMap<>();
+
+    private FeatureFlagRegistry(){}
+
+    public static void initFrom(CoreConfig cfg){
+        FLAGS.clear();
+        FLAGS.putAll(cfg.featureFlags);
+        LOG.info("Feature flags loaded: {}", FLAGS);
+    }
+
+    public static boolean isEnabled(String flag){
+        return FLAGS.getOrDefault(flag, false);
+    }
+
+    // wire into config hot-reload
+    public static void wireReload(){
+        ConfigManager.init(FeatureFlagRegistry::initFrom);
+        initFrom(ConfigManager.get());
+    }
 }

--- a/src/main/java/org/github/shatterz/sentinelcore/flags/FeatureFlagRegistry.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/flags/FeatureFlagRegistry.java
@@ -1,0 +1,4 @@
+package org.github.shatterz.sentinelcore.flags;
+
+public class FeatureFlagRegistry {
+}

--- a/src/main/java/org/github/shatterz/sentinelcore/log/SentinelCategories.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/log/SentinelCategories.java
@@ -1,0 +1,13 @@
+package org.github.shatterz.sentinelcore.log;
+
+public enum SentinelCategories {
+    AUDIT("audit"),
+    PERM("perm"),
+    MOVE("move"),
+    MODMODE("modmode"),
+    SPAWN("spawn");
+
+    private final String id;
+    SentinelCategories(String id){ this.id = id; }
+    public String id(){ return id; }
+}

--- a/src/main/java/org/github/shatterz/sentinelcore/log/SentinelCategories.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/log/SentinelCategories.java
@@ -1,13 +1,19 @@
 package org.github.shatterz.sentinelcore.log;
 
 public enum SentinelCategories {
-    AUDIT("audit"),
-    PERM("perm"),
-    MOVE("move"),
-    MODMODE("modmode"),
-    SPAWN("spawn");
+  AUDIT("audit"),
+  PERM("perm"),
+  MOVE("move"),
+  MODMODE("modmode"),
+  SPAWN("spawn");
 
-    private final String id;
-    SentinelCategories(String id){ this.id = id; }
-    public String id(){ return id; }
+  private final String id;
+
+  SentinelCategories(String id) {
+    this.id = id;
+  }
+
+  public String id() {
+    return id;
+  }
 }

--- a/src/main/java/org/github/shatterz/sentinelcore/log/SentinelLogger.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/log/SentinelLogger.java
@@ -1,0 +1,28 @@
+package org.github.shatterz.sentinelcore.log;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class SentinelLogger {
+    private static final Logger ROOT = LoggerFactory.getLogger("SentinelCore");
+    private static final Map<SentinelCategories, Logger> BY_CAT = new EnumMap<>(SentinelCategories.class);
+    private static final Map<String, Logger> BY_ID = new ConcurrentHashMap<>();
+
+    static {
+        for (SentinelCategories c : SentinelCategories.values()) {
+            BY_CAT.put(c, LoggerFactory.getLogger("SentinelCore/" + c.id()));
+        }
+    }
+
+    private SentinelLogger(){}
+
+    public static Logger root() { return ROOT; }
+    public static Logger cat(SentinelCategories cat){ return BY_CAT.get(cat); }
+    public static Logger cat(String id){
+        return BY_ID.computeIfAbsent(id, k -> LoggerFactory.getLogger("SentinelCore/" + k));
+    }
+}

--- a/src/main/java/org/github/shatterz/sentinelcore/log/SentinelLogger.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/log/SentinelLogger.java
@@ -1,28 +1,34 @@
 package org.github.shatterz.sentinelcore.log;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class SentinelLogger {
-    private static final Logger ROOT = LoggerFactory.getLogger("SentinelCore");
-    private static final Map<SentinelCategories, Logger> BY_CAT = new EnumMap<>(SentinelCategories.class);
-    private static final Map<String, Logger> BY_ID = new ConcurrentHashMap<>();
+  private static final Logger ROOT = LoggerFactory.getLogger("SentinelCore");
+  private static final Map<SentinelCategories, Logger> BY_CAT =
+      new EnumMap<>(SentinelCategories.class);
+  private static final Map<String, Logger> BY_ID = new ConcurrentHashMap<>();
 
-    static {
-        for (SentinelCategories c : SentinelCategories.values()) {
-            BY_CAT.put(c, LoggerFactory.getLogger("SentinelCore/" + c.id()));
-        }
+  static {
+    for (SentinelCategories c : SentinelCategories.values()) {
+      BY_CAT.put(c, LoggerFactory.getLogger("SentinelCore/" + c.id()));
     }
+  }
 
-    private SentinelLogger(){}
+  private SentinelLogger() {}
 
-    public static Logger root() { return ROOT; }
-    public static Logger cat(SentinelCategories cat){ return BY_CAT.get(cat); }
-    public static Logger cat(String id){
-        return BY_ID.computeIfAbsent(id, k -> LoggerFactory.getLogger("SentinelCore/" + k));
-    }
+  public static Logger root() {
+    return ROOT;
+  }
+
+  public static Logger cat(SentinelCategories cat) {
+    return BY_CAT.get(cat);
+  }
+
+  public static Logger cat(String id) {
+    return BY_ID.computeIfAbsent(id, k -> LoggerFactory.getLogger("SentinelCore/" + k));
+  }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -5,9 +5,6 @@
   "name": "SentinelCore",
   "description": "Server-side core for spawn systems, staff tools, auditing, and QoL.",
   "authors": ["djshatterz"],
-  "contact": {
-    "sources": "https://github.com/djshatterz/SentinelCore"
-  },
   "license": "MIT",
   "environment": "server",
   "entrypoints": {
@@ -16,8 +13,8 @@
     ]
   },
   "depends": {
-    "fabricloader": ">=${loader_version}",
-    "minecraft": ">=${minecraft_version}",
+    "fabricloader": ">=0.17.3",
+    "minecraft": "1.21.10",
     "java": ">=21"
   }
 }


### PR DESCRIPTION
### Summary
Implements [Issue #1](https://github.com/djshatterz/SentinelCore/issues/1):  
Initialize Fabric Loom server-side mod for Minecraft 1.21.10.

### Changes
- ✅ Fabric Loom baseline (server-side only)
- ✅ Central logger with categories (`audit`, `perm`, `move`, `modmode`, `spawn`)
- ✅ YAML/JSON config loader with default creation and hot-reload watcher
- ✅ Feature flag registry integrated with config reload
- ✅ Gradle bootstrap to auto-create `run/eula.txt` + `server.properties`

### Testing
1. Run `.\gradlew.bat runServer`  
2. Check console for:
   - `SentinelCore Initializing base systems...`
   - `Config reloaded...`
   - `Audit/Perm/Move/ModMode/Spawn logging ready`
3. Verify config file at `run/config/sentinelcore/config.yaml` reloads automatically on edit.

### Notes
- Uses Temurin 21.
- Verified build + server start locally.
- Next step: Phase 1 – Permission Manager skeleton.
