### PR TITLE
SpawnProtection: Cylinder Zone + Whitelist + Admin Commands

### DIFF
--- a/docs/TODO_PHYSICS_PROTECTIONS.md
+++ b/docs/TODO_PHYSICS_PROTECTIONS.md
@@ -1,0 +1,73 @@
+# TODO: Complete Physics Protections for Spawn Zone
+
+## Status
+The following physics protections need proper implementation and testing. Initial mixin scaffolding exists but requires correct method/field mappings for Minecraft 1.21.10.
+
+## Pending Features
+
+### 1. Explosion Protection
+**Goal**: Prevent explosions from destroying blocks inside the spawn protection zone.
+
+**Current State**: 
+- Mixin exists at `src/main/java/org/github/shatterz/sentinelcore/mixin/ExplosionMixin.java`
+- Disabled in `sentinelcore.mixins.json` due to mapping issues
+- Config flag ready: `spawnProtection.physics.blockExplosions`
+
+**Issues**:
+- Yarn mappings for `Explosion` class fields may not match
+- Method `affectWorld` descriptor not found in current mappings
+
+**Next Steps**:
+- Verify correct Yarn-mapped field names for `world` and `affectedBlocks` in Explosion class
+- Confirm method name for explosion detonation (may be `affectWorld`, `explode`, or similar)
+- Alternative: Use Fabric API's explosion events if/when available for 1.21.10
+
+### 2. Piston Movement Blocking
+**Goal**: Prevent pistons from pushing/pulling blocks into or out of the spawn protection zone.
+
+**Current State**:
+- Mixin exists at `src/main/java/org/github/shatterz/sentinelcore/mixin/PistonHandlerMixin.java`
+- Disabled in `sentinelcore.mixins.json` due to runtime issues
+- Config flag ready: `spawnProtection.physics.blockPistons`
+
+**Issues**:
+- Runtime behavior not working as expected
+- May need to target different method or use different injection point
+
+**Next Steps**:
+- Test with different injection points (`tryMove` at various locations)
+- Consider targeting `calculatePush` or piston block methods directly
+- Verify `PistonHandler` constructor fields are correctly shadowed
+- Alternative: Use Fabric API's piston events if/when available for 1.21.10
+
+## Working Features (Already Implemented)
+
+✅ Block placement/breaking prevention (except whitelisted shulker boxes)  
+✅ Whitelisted block interactions (crafting tables, chests, etc.)  
+✅ Fluid placement/pickup blocking (buckets)  
+✅ Mob spawn suppression (via `ServerEntityEvents.ENTITY_LOAD`)  
+✅ Enderman grief prevention (drops carried blocks when entering zone)  
+✅ Creative mode bypass  
+✅ Permission-based bypass (`sentinelcore.spawnprot.bypass`)  
+
+## Implementation Priority
+
+1. **High Priority**: Explosion protection (most impactful for spawn integrity)
+2. **Medium Priority**: Piston blocking (less common but important for grief prevention)
+
+## Testing Checklist (When Implemented)
+
+- [ ] TNT detonation at zone boundary - blocks inside should remain
+- [ ] Creeper explosion near zone - no block damage inside
+- [ ] Piston push from outside into zone - should fail
+- [ ] Piston push from inside zone - should fail  
+- [ ] Piston pull into zone - should fail
+- [ ] Config flags properly gate each feature
+- [ ] No console errors or warnings
+- [ ] Performance impact acceptable (test with multiple explosions/pistons)
+
+## References
+
+- Mixin files: `src/main/java/org/github/shatterz/sentinelcore/mixin/`
+- Helper methods: `SpawnProtectionManager.shouldProtectExplosion()`, `shouldProtectPiston()`
+- Config schema: `CoreConfig.SpawnProtection.Physics`

--- a/src/main/java/org/github/shatterz/sentinelcore/SentinelCore.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/SentinelCore.java
@@ -13,6 +13,8 @@ import org.github.shatterz.sentinelcore.names.CommunityPrefixManager;
 import org.github.shatterz.sentinelcore.perm.PermCommands;
 import org.github.shatterz.sentinelcore.perm.PermissionBootstrap;
 import org.github.shatterz.sentinelcore.perm.events.PlayerConnectionListener;
+import org.github.shatterz.sentinelcore.protection.SpawnProtCommands;
+import org.github.shatterz.sentinelcore.protection.SpawnProtectionManager;
 import org.slf4j.Logger;
 
 public final class SentinelCore implements ModInitializer {
@@ -46,6 +48,13 @@ public final class SentinelCore implements ModInitializer {
     org.github.shatterz.sentinelcore.config.ConfigManager.addReloadListener(
         MovementManager::applyConfig);
     MoveCommands.register();
+
+    // Spawn protection system + commands
+    SpawnProtectionManager.applyConfig(org.github.shatterz.sentinelcore.config.ConfigManager.get());
+    org.github.shatterz.sentinelcore.config.ConfigManager.addReloadListener(
+        SpawnProtectionManager::applyConfig);
+    SpawnProtectionManager.registerListeners();
+    SpawnProtCommands.register();
 
     // Write a startup audit record so logs are always tail-able right after boot
     try {

--- a/src/main/java/org/github/shatterz/sentinelcore/config/CoreConfig.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/config/CoreConfig.java
@@ -24,6 +24,9 @@ public class CoreConfig {
   /** Community and team prefix configuration. */
   public Community community = new Community();
 
+  /** Spawn protection configuration. */
+  public SpawnProtection spawnProtection = new SpawnProtection();
+
   /** Default constructor populates nothing; use defaults() to create a prefilled config. */
   public CoreConfig() {}
 
@@ -222,6 +225,37 @@ public class CoreConfig {
         public boolean bold = false;
         public boolean italic = false;
       }
+    }
+  }
+
+  /** Spawn protection configuration schema. */
+  public static class SpawnProtection {
+    public boolean enabled = true;
+    public String shape = "cylinder";
+    public int radius = 25;
+    public int bottomY = 50;
+    public String center = "world:0,100,0"; // format: "world:x,y,z"
+    public Whitelist whitelist = new Whitelist();
+    public Physics physics = new Physics();
+
+    public static class Whitelist {
+      public Set<String> interact = new HashSet<>();
+
+      public Whitelist() {
+        interact.add("minecraft:crafting_table");
+        interact.add("minecraft:chest");
+        interact.add("minecraft:ender_chest");
+        interact.add("minecraft:enchanting_table");
+        interact.add("minecraft:shulker_box");
+      }
+    }
+
+    public static class Physics {
+      public boolean blockExplosions = true;
+      public boolean blockPistons = true;
+      public boolean blockFluids = true;
+      public boolean blockEndermen = true;
+      public boolean blockMobSpawn = true;
     }
   }
 }

--- a/src/main/java/org/github/shatterz/sentinelcore/config/CoreConfig.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/config/CoreConfig.java
@@ -235,6 +235,10 @@ public class CoreConfig {
     public int radius = 25;
     public int bottomY = 50;
     public String center = "world:0,100,0"; // format: "world:x,y,z"
+
+    /** If true, players with the permission node can bypass spawn protection. */
+    public boolean allowPermissionBypass = true;
+
     public Whitelist whitelist = new Whitelist();
     public Physics physics = new Physics();
 

--- a/src/main/java/org/github/shatterz/sentinelcore/mixin/EndermanEntityMixin.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/mixin/EndermanEntityMixin.java
@@ -1,0 +1,26 @@
+package org.github.shatterz.sentinelcore.mixin;
+
+import net.minecraft.entity.mob.EndermanEntity;
+import net.minecraft.util.math.BlockPos;
+import org.github.shatterz.sentinelcore.protection.SpawnProtectionManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/** Prevents Endermen from picking up or placing blocks inside the spawn protection zone. */
+@Mixin(EndermanEntity.class)
+public class EndermanEntityMixin {
+
+  @Inject(method = "tickMovement", at = @At("HEAD"))
+  private void sentinelcore$protectSpawnFromEnderman(CallbackInfo ci) {
+    EndermanEntity self = (EndermanEntity) (Object) this;
+    BlockPos pos = self.getBlockPos();
+
+    // If Enderman is carrying a block and inside the zone, drop it
+    if (self.getCarriedBlock() != null
+        && SpawnProtectionManager.shouldProtectEnderman(self.getEntityWorld(), pos)) {
+      self.setCarriedBlock(null);
+    }
+  }
+}

--- a/src/main/java/org/github/shatterz/sentinelcore/mixin/ExplosionMixin.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/mixin/ExplosionMixin.java
@@ -1,0 +1,26 @@
+package org.github.shatterz.sentinelcore.mixin;
+
+import java.util.List;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.explosion.Explosion;
+import org.github.shatterz.sentinelcore.protection.SpawnProtectionManager;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/** Prevents explosions from damaging blocks inside the spawn protection zone. */
+@Mixin(Explosion.class)
+public class ExplosionMixin {
+  @Shadow @Final private World world;
+
+  @Shadow @Final private List<BlockPos> affectedBlocks;
+
+  @Inject(method = "affectWorld", at = @At("HEAD"))
+  private void sentinelcore$protectSpawnFromExplosions(CallbackInfo ci) {
+    affectedBlocks.removeIf(pos -> SpawnProtectionManager.shouldProtectExplosion(world, pos));
+  }
+}

--- a/src/main/java/org/github/shatterz/sentinelcore/mixin/PistonHandlerMixin.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/mixin/PistonHandlerMixin.java
@@ -1,0 +1,30 @@
+package org.github.shatterz.sentinelcore.mixin;
+
+import net.minecraft.block.piston.PistonHandler;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+import org.github.shatterz.sentinelcore.protection.SpawnProtectionManager;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/** Prevents pistons from moving blocks into or out of the spawn protection zone. */
+@Mixin(PistonHandler.class)
+public class PistonHandlerMixin {
+  @Shadow @Final private World world;
+
+  @Shadow @Final private BlockPos posFrom;
+
+  @Shadow @Final private Direction motionDirection;
+
+  @Inject(method = "tryMove", at = @At("HEAD"), cancellable = true)
+  private void sentinelcore$protectSpawnFromPistons(CallbackInfoReturnable<Boolean> cir) {
+    if (SpawnProtectionManager.shouldProtectPiston(world, posFrom, motionDirection)) {
+      cir.setReturnValue(false);
+    }
+  }
+}

--- a/src/main/java/org/github/shatterz/sentinelcore/protection/SpawnProtCommands.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/protection/SpawnProtCommands.java
@@ -1,0 +1,207 @@
+package org.github.shatterz.sentinelcore.protection;
+
+import static com.mojang.brigadier.arguments.IntegerArgumentType.getInteger;
+import static com.mojang.brigadier.arguments.IntegerArgumentType.integer;
+import static net.minecraft.server.command.CommandManager.argument;
+import static net.minecraft.server.command.CommandManager.literal;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.math.Vec3d;
+import org.github.shatterz.sentinelcore.config.ConfigManager;
+import org.github.shatterz.sentinelcore.config.CoreConfig;
+import org.github.shatterz.sentinelcore.perm.PermissionManager;
+
+/**
+ * Admin commands for spawn protection: /spawnprot
+ * info|enable|disable|setcenter|setradius|setbottomy
+ */
+public final class SpawnProtCommands {
+  private SpawnProtCommands() {}
+
+  public static void register() {
+    CommandRegistrationCallback.EVENT.register(
+        (dispatcher, registryAccess, environment) -> register(dispatcher));
+  }
+
+  private static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
+    dispatcher.register(
+        literal("spawnprot")
+            .then(
+                literal("info")
+                    .requires(src -> has(src, "sentinelcore.spawnprot.info"))
+                    .executes(
+                        ctx -> {
+                          CoreConfig.SpawnProtection cfg = SpawnProtectionManager.getConfig();
+                          Vec3d center = SpawnProtectionManager.getCenter();
+                          String world = SpawnProtectionManager.getWorldId();
+                          ctx.getSource()
+                              .sendFeedback(
+                                  () -> Text.literal("Spawn Protection").formatted(Formatting.AQUA),
+                                  false);
+                          ctx.getSource()
+                              .sendFeedback(
+                                  () -> Text.literal(String.format("  Enabled: %s", cfg.enabled)),
+                                  false);
+                          ctx.getSource()
+                              .sendFeedback(
+                                  () -> Text.literal(String.format("  Shape: %s", cfg.shape)),
+                                  false);
+                          ctx.getSource()
+                              .sendFeedback(
+                                  () ->
+                                      Text.literal(
+                                          String.format(
+                                              "  Center: %s @ %.1f,%.1f,%.1f",
+                                              world, center.x, center.y, center.z)),
+                                  false);
+                          ctx.getSource()
+                              .sendFeedback(
+                                  () -> Text.literal(String.format("  Radius: %d", cfg.radius)),
+                                  false);
+                          ctx.getSource()
+                              .sendFeedback(
+                                  () -> Text.literal(String.format("  Bottom Y: %d", cfg.bottomY)),
+                                  false);
+                          return 1;
+                        }))
+            .then(
+                literal("enable")
+                    .requires(src -> has(src, "sentinelcore.spawnprot.admin"))
+                    .executes(
+                        ctx -> {
+                          CoreConfig cfg = ConfigManager.get();
+                          cfg.spawnProtection.enabled = true;
+                          try {
+                            ConfigManager.saveYAML(cfg);
+                            SpawnProtectionManager.applyConfig(cfg);
+                            ctx.getSource()
+                                .sendFeedback(
+                                    () ->
+                                        Text.literal("Spawn protection enabled.")
+                                            .formatted(Formatting.GREEN),
+                                    true);
+                            return 1;
+                          } catch (Exception e) {
+                            ctx.getSource().sendError(Text.literal("Failed to save config."));
+                            return 0;
+                          }
+                        }))
+            .then(
+                literal("disable")
+                    .requires(src -> has(src, "sentinelcore.spawnprot.admin"))
+                    .executes(
+                        ctx -> {
+                          CoreConfig cfg = ConfigManager.get();
+                          cfg.spawnProtection.enabled = false;
+                          try {
+                            ConfigManager.saveYAML(cfg);
+                            SpawnProtectionManager.applyConfig(cfg);
+                            ctx.getSource()
+                                .sendFeedback(
+                                    () ->
+                                        Text.literal("Spawn protection disabled.")
+                                            .formatted(Formatting.YELLOW),
+                                    true);
+                            return 1;
+                          } catch (Exception e) {
+                            ctx.getSource().sendError(Text.literal("Failed to save config."));
+                            return 0;
+                          }
+                        }))
+            .then(
+                literal("setcenter")
+                    .requires(src -> has(src, "sentinelcore.spawnprot.admin"))
+                    .executes(
+                        ctx -> {
+                          ServerPlayerEntity p = ctx.getSource().getPlayer();
+                          if (p == null) {
+                            ctx.getSource().sendError(Text.literal("Players only."));
+                            return 0;
+                          }
+                          CoreConfig cfg = ConfigManager.get();
+                          String world = p.getEntityWorld().getRegistryKey().getValue().toString();
+                          String centerStr =
+                              String.format(
+                                  "%s:%d,%d,%d",
+                                  world, (int) p.getX(), (int) p.getY(), (int) p.getZ());
+                          cfg.spawnProtection.center = centerStr;
+                          try {
+                            ConfigManager.saveYAML(cfg);
+                            SpawnProtectionManager.applyConfig(cfg);
+                            ctx.getSource()
+                                .sendFeedback(
+                                    () ->
+                                        Text.literal("Spawn protection center set to: " + centerStr)
+                                            .formatted(Formatting.GREEN),
+                                    true);
+                            return 1;
+                          } catch (Exception e) {
+                            ctx.getSource().sendError(Text.literal("Failed to save config."));
+                            return 0;
+                          }
+                        }))
+            .then(
+                literal("setradius")
+                    .requires(src -> has(src, "sentinelcore.spawnprot.admin"))
+                    .then(
+                        argument("blocks", integer(1, 500))
+                            .executes(
+                                ctx -> {
+                                  int r = getInteger(ctx, "blocks");
+                                  CoreConfig cfg = ConfigManager.get();
+                                  cfg.spawnProtection.radius = r;
+                                  try {
+                                    ConfigManager.saveYAML(cfg);
+                                    SpawnProtectionManager.applyConfig(cfg);
+                                    ctx.getSource()
+                                        .sendFeedback(
+                                            () ->
+                                                Text.literal("Spawn protection radius set to: " + r)
+                                                    .formatted(Formatting.GREEN),
+                                            true);
+                                    return 1;
+                                  } catch (Exception e) {
+                                    ctx.getSource()
+                                        .sendError(Text.literal("Failed to save config."));
+                                    return 0;
+                                  }
+                                })))
+            .then(
+                literal("setbottomy")
+                    .requires(src -> has(src, "sentinelcore.spawnprot.admin"))
+                    .then(
+                        argument("y", integer(-64, 320))
+                            .executes(
+                                ctx -> {
+                                  int y = getInteger(ctx, "y");
+                                  CoreConfig cfg = ConfigManager.get();
+                                  cfg.spawnProtection.bottomY = y;
+                                  try {
+                                    ConfigManager.saveYAML(cfg);
+                                    SpawnProtectionManager.applyConfig(cfg);
+                                    ctx.getSource()
+                                        .sendFeedback(
+                                            () ->
+                                                Text.literal(
+                                                        "Spawn protection bottom Y set to: " + y)
+                                                    .formatted(Formatting.GREEN),
+                                            true);
+                                    return 1;
+                                  } catch (Exception e) {
+                                    ctx.getSource()
+                                        .sendError(Text.literal("Failed to save config."));
+                                    return 0;
+                                  }
+                                }))));
+  }
+
+  private static boolean has(ServerCommandSource src, String node) {
+    if (src.getPlayer() == null) return src.hasPermissionLevel(3);
+    return PermissionManager.has(src.getPlayer(), node) || src.hasPermissionLevel(3);
+  }
+}

--- a/src/main/java/org/github/shatterz/sentinelcore/protection/SpawnProtectionManager.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/protection/SpawnProtectionManager.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 public final class SpawnProtectionManager {
   private static final Logger LOG = SentinelLogger.cat(SentinelCategories.SPAWN);
   private static final Pattern CENTER_PATTERN =
-      Pattern.compile("([^:]+):(-?\\d+),(-?\\d+),(-?\\d+)");
+      Pattern.compile("([^:]+:[^:]+):(-?\\d+),(-?\\d+),(-?\\d+)");
 
   private static volatile CoreConfig.SpawnProtection CFG = new CoreConfig.SpawnProtection();
   private static volatile Vec3d CENTER = new Vec3d(0, 100, 0);
@@ -134,7 +134,7 @@ public final class SpawnProtectionManager {
       CENTER = new Vec3d(x, y, z);
     } else {
       LOG.warn("Invalid spawn protection center format: {}", s);
-      WORLD_ID = "world";
+      WORLD_ID = "minecraft:overworld";
       CENTER = new Vec3d(0, 100, 0);
     }
   }

--- a/src/main/java/org/github/shatterz/sentinelcore/protection/SpawnProtectionManager.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/protection/SpawnProtectionManager.java
@@ -1,0 +1,153 @@
+package org.github.shatterz.sentinelcore.protection;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
+import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
+import net.fabricmc.fabric.api.event.player.UseBlockCallback;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.registry.Registries;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.text.Text;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+import org.github.shatterz.sentinelcore.config.CoreConfig;
+import org.github.shatterz.sentinelcore.log.SentinelCategories;
+import org.github.shatterz.sentinelcore.log.SentinelLogger;
+import org.github.shatterz.sentinelcore.perm.PermissionManager;
+import org.slf4j.Logger;
+
+/**
+ * Protects spawn region from building, explosions, and grief. Allows creative-mode bypass and
+ * whitelisted interactions.
+ */
+public final class SpawnProtectionManager {
+  private static final Logger LOG = SentinelLogger.cat(SentinelCategories.SPAWN);
+  private static final Pattern CENTER_PATTERN =
+      Pattern.compile("([^:]+):(-?\\d+),(-?\\d+),(-?\\d+)");
+
+  private static volatile CoreConfig.SpawnProtection CFG = new CoreConfig.SpawnProtection();
+  private static volatile Vec3d CENTER = new Vec3d(0, 100, 0);
+  private static volatile String WORLD_ID = "world";
+
+  private SpawnProtectionManager() {}
+
+  public static void applyConfig(CoreConfig cfg) {
+    if (cfg != null && cfg.spawnProtection != null) {
+      CFG = cfg.spawnProtection;
+      parseCenter(CFG.center);
+      LOG.info(
+          "SpawnProtection config applied: enabled={} shape={} radius={} bottomY={} center={} world={}",
+          CFG.enabled,
+          CFG.shape,
+          CFG.radius,
+          CFG.bottomY,
+          CENTER,
+          WORLD_ID);
+    }
+  }
+
+  public static void registerListeners() {
+    // Block break prevention
+    PlayerBlockBreakEvents.BEFORE.register(
+        (world, player, pos, state, blockEntity) -> {
+          if (isProtected(world, pos, player)) {
+            if (player instanceof ServerPlayerEntity sp) {
+              sp.sendMessage(Text.literal("Spawn is protected."), true);
+            }
+            return false;
+          }
+          return true;
+        });
+
+    // Block place prevention (handled via AttackBlock for quick-break and UseBlock for place)
+    AttackBlockCallback.EVENT.register(
+        (player, world, hand, pos, direction) -> {
+          if (isProtected(world, pos, player)) {
+            if (player instanceof ServerPlayerEntity sp) {
+              sp.sendMessage(Text.literal("Spawn is protected."), true);
+            }
+            return ActionResult.FAIL;
+          }
+          return ActionResult.PASS;
+        });
+
+    // Interact whitelist
+    UseBlockCallback.EVENT.register(
+        (player, world, hand, hitResult) -> {
+          BlockPos pos = hitResult.getBlockPos();
+          if (isProtected(world, pos, player)) {
+            BlockState state = world.getBlockState(pos);
+            String blockId = Registries.BLOCK.getId(state.getBlock()).toString();
+            if (!CFG.whitelist.interact.contains(blockId)) {
+              if (player instanceof ServerPlayerEntity sp) {
+                sp.sendMessage(Text.literal("Spawn is protected."), true);
+              }
+              return ActionResult.FAIL;
+            }
+          }
+          return ActionResult.PASS;
+        });
+
+    LOG.info("SpawnProtection event listeners registered.");
+  }
+
+  private static boolean isProtected(World world, BlockPos pos, PlayerEntity player) {
+    if (!CFG.enabled) return false;
+    if (!(world instanceof ServerWorld sw)) return false;
+
+    // Check world match
+    String wid = sw.getRegistryKey().getValue().toString();
+    if (!wid.equals(WORLD_ID)) return false;
+
+    // Creative or admin bypass
+    if (player.isCreative()) return false;
+    if (player instanceof ServerPlayerEntity sp) {
+      if (PermissionManager.has(sp, "sentinelcore.spawnprot.bypass")) return false;
+    }
+
+    // Shape check
+    if ("cylinder".equalsIgnoreCase(CFG.shape)) {
+      double dx = pos.getX() + 0.5 - CENTER.x;
+      double dz = pos.getZ() + 0.5 - CENTER.z;
+      double distSq = dx * dx + dz * dz;
+      if (distSq > CFG.radius * CFG.radius) return false;
+      // Bottom Y check
+      if (pos.getY() < CFG.bottomY) return false;
+    }
+    // Add sphere support if needed
+
+    return true;
+  }
+
+  private static void parseCenter(String s) {
+    Matcher m = CENTER_PATTERN.matcher(s);
+    if (m.matches()) {
+      WORLD_ID = m.group(1);
+      double x = Double.parseDouble(m.group(2));
+      double y = Double.parseDouble(m.group(3));
+      double z = Double.parseDouble(m.group(4));
+      CENTER = new Vec3d(x, y, z);
+    } else {
+      LOG.warn("Invalid spawn protection center format: {}", s);
+      WORLD_ID = "world";
+      CENTER = new Vec3d(0, 100, 0);
+    }
+  }
+
+  public static CoreConfig.SpawnProtection getConfig() {
+    return CFG;
+  }
+
+  public static Vec3d getCenter() {
+    return CENTER;
+  }
+
+  public static String getWorldId() {
+    return WORLD_ID;
+  }
+}

--- a/src/main/java/org/github/shatterz/sentinelcore/protection/SpawnProtectionManager.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/protection/SpawnProtectionManager.java
@@ -41,13 +41,14 @@ public final class SpawnProtectionManager {
       CFG = cfg.spawnProtection;
       parseCenter(CFG.center);
       LOG.info(
-          "SpawnProtection config applied: enabled={} shape={} radius={} bottomY={} center={} world={}",
+          "SpawnProtection config applied: enabled={} shape={} radius={} bottomY={} center={} world={} permBypass={}",
           CFG.enabled,
           CFG.shape,
           CFG.radius,
           CFG.bottomY,
           CENTER,
-          WORLD_ID);
+          WORLD_ID,
+          CFG.allowPermissionBypass);
     }
   }
 
@@ -108,9 +109,15 @@ public final class SpawnProtectionManager {
     }
 
     // Creative or admin bypass
-    if (player.isCreative()) return false;
-    if (player instanceof ServerPlayerEntity sp) {
-      if (PermissionManager.has(sp, "sentinelcore.spawnprot.bypass")) return false;
+    if (player.isCreative()) {
+      LOG.debug("Bypass (creative) at {} for player {}", pos, player.getName().getString());
+      return false;
+    }
+    if (CFG.allowPermissionBypass && player instanceof ServerPlayerEntity sp) {
+      if (PermissionManager.has(sp, "sentinelcore.spawnprot.bypass")) {
+        LOG.debug("Bypass (permission) at {} for player {}", pos, player.getName().getString());
+        return false;
+      }
     }
 
     // Shape check

--- a/src/main/java/org/github/shatterz/sentinelcore/protection/SpawnProtectionManager.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/protection/SpawnProtectionManager.java
@@ -102,7 +102,10 @@ public final class SpawnProtectionManager {
 
     // Check world match
     String wid = sw.getRegistryKey().getValue().toString();
-    if (!wid.equals(WORLD_ID)) return false;
+    if (!wid.equals(WORLD_ID)) {
+      LOG.debug("World mismatch: {} != {}", wid, WORLD_ID);
+      return false;
+    }
 
     // Creative or admin bypass
     if (player.isCreative()) return false;
@@ -115,9 +118,17 @@ public final class SpawnProtectionManager {
       double dx = pos.getX() + 0.5 - CENTER.x;
       double dz = pos.getZ() + 0.5 - CENTER.z;
       double distSq = dx * dx + dz * dz;
-      if (distSq > CFG.radius * CFG.radius) return false;
+      double maxDistSq = CFG.radius * CFG.radius;
+      if (distSq > maxDistSq) {
+        LOG.debug("Outside radius: dist²={} > max²={}", distSq, maxDistSq);
+        return false;
+      }
       // Bottom Y check
-      if (pos.getY() < CFG.bottomY) return false;
+      if (pos.getY() < CFG.bottomY) {
+        LOG.debug("Below bottom Y: {} < {}", pos.getY(), CFG.bottomY);
+        return false;
+      }
+      LOG.debug("Protection active at {} for player {}", pos, player.getName().getString());
     }
     // Add sphere support if needed
 

--- a/src/main/java/org/github/shatterz/sentinelcore/protection/SpawnProtectionManager.java
+++ b/src/main/java/org/github/shatterz/sentinelcore/protection/SpawnProtectionManager.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
 import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
+import net.fabricmc.fabric.api.event.player.UseItemCallback;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
@@ -14,6 +15,8 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
@@ -59,6 +62,11 @@ public final class SpawnProtectionManager {
     PlayerBlockBreakEvents.BEFORE.register(
         (world, player, pos, state, blockEntity) -> {
           if (isProtected(world, pos, player)) {
+            // Allow breaking shulker boxes inside the zone
+            String blockId = Registries.BLOCK.getId(state.getBlock()).toString();
+            if (isShulker(blockId)) {
+              return true;
+            }
             if (player instanceof ServerPlayerEntity sp) {
               sp.sendMessage(Text.literal("Spawn is protected."), true);
             }
@@ -90,7 +98,7 @@ public final class SpawnProtectionManager {
           if (isProtected(world, clicked, player)) {
             BlockState state = world.getBlockState(clicked);
             String blockId = Registries.BLOCK.getId(state.getBlock()).toString();
-            boolean whitelisted = CFG.whitelist.interact.contains(blockId);
+            boolean whitelisted = isWhitelistedInteract(blockId);
             if (whitelisted && !player.isSneaking()) {
               return ActionResult.PASS; // allow opening containers etc.
             }
@@ -104,7 +112,12 @@ public final class SpawnProtectionManager {
           // If attempting to place a block or fluid into the zone from outside
           boolean placingBlock = held instanceof BlockItem;
           boolean usingBucket = held instanceof net.minecraft.item.BucketItem;
-          if ((placingBlock || usingBucket) && isProtected(world, target, player)) {
+          boolean placingShulker =
+              placingBlock
+                  && isShulker(Registries.BLOCK.getId(((BlockItem) held).getBlock()).toString());
+
+          if ((usingBucket || (placingBlock && !placingShulker))
+              && isProtected(world, target, player)) {
             if (player instanceof ServerPlayerEntity sp) {
               sp.sendMessage(Text.literal("Spawn is protected."), true);
             }
@@ -114,7 +127,45 @@ public final class SpawnProtectionManager {
           return ActionResult.PASS;
         });
 
+    // Catch bucket usage when not strictly targeting a block (e.g., air raycasts)
+    UseItemCallback.EVENT.register(
+        (player, world, hand) -> {
+          Item held = player.getStackInHand(hand).getItem();
+          boolean maybeBucket =
+              held instanceof net.minecraft.item.BucketItem
+                  || held == net.minecraft.item.Items.BUCKET;
+          if (!maybeBucket) return ActionResult.PASS;
+
+          // Raycast to find the block being targeted and derived placement target
+          HitResult hr = player.raycast(5.0, 0.0f, true);
+          if (hr instanceof BlockHitResult bhr) {
+            BlockPos clicked = bhr.getBlockPos();
+            BlockPos target = clicked.offset(bhr.getSide());
+            if (isProtected(world, clicked, player) || isProtected(world, target, player)) {
+              if (player instanceof ServerPlayerEntity sp) {
+                sp.sendMessage(Text.literal("Spawn is protected."), true);
+              }
+              return ActionResult.FAIL;
+            }
+          }
+          return ActionResult.PASS;
+        });
+
     LOG.info("SpawnProtection event listeners registered.");
+  }
+
+  private static boolean isWhitelistedInteract(String blockId) {
+    if (CFG.whitelist.interact.contains(blockId)) return true;
+    // Special-case: any colored shulker box when base id is present
+    if (CFG.whitelist.interact.contains("minecraft:shulker_box")
+        && (blockId.endsWith("_shulker_box") || blockId.equals("minecraft:shulker_box"))) {
+      return true;
+    }
+    return false;
+  }
+
+  private static boolean isShulker(String blockId) {
+    return blockId.endsWith("_shulker_box") || blockId.equals("minecraft:shulker_box");
   }
 
   private static boolean isInsideZone(World world, BlockPos pos) {

--- a/src/main/resources/sentinelcore.mixins.json
+++ b/src/main/resources/sentinelcore.mixins.json
@@ -4,9 +4,7 @@
   "package": "org.github.shatterz.sentinelcore.mixin",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
-    "EndermanEntityMixin",
-    "ExplosionMixin",
-    "PistonHandlerMixin"
+    "EndermanEntityMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/main/resources/sentinelcore.mixins.json
+++ b/src/main/resources/sentinelcore.mixins.json
@@ -3,7 +3,11 @@
   "minVersion": "0.8",
   "package": "org.github.shatterz.sentinelcore.mixin",
   "compatibilityLevel": "JAVA_21",
-  "mixins": [],
+  "mixins": [
+    "EndermanEntityMixin",
+    "ExplosionMixin",
+    "PistonHandlerMixin"
+  ],
   "injectors": {
     "defaultRequire": 1
   },


### PR DESCRIPTION
Summary
- Adds SpawnProtection system with configurable cylinder geometry protecting spawn from grief and unwanted building.
- Configurable via CoreConfig.spawnProtection (enabled, shape, radius, bottomY, center coordinate).
- Whitelist allows interaction with specific blocks (crafting table, chest, ender chest, enchanting table, shulker box).
- Creative mode and permission-based bypass (sentinelcore.spawnprot.bypass).
- Admin commands: /spawnprot info|enable|disable|setcenter|setradius|setbottomy

Implementation Notes
- Uses Fabric event hooks: PlayerBlockBreakEvents.BEFORE, AttackBlockCallback, UseBlockCallback.
- Center format: "world:x,y,z" parsed at config load and hot-reload.
- Cylinder distance check: horizontal radius (XZ plane) + bottomY clamp. Top Y extends to world max.
- Physics hardening stubs prepared (explosions, pistons, fluids, enderman, mob spawns) but not wired yet.
- Permission: sentinelcore.spawnprot.info (view), sentinelcore.spawnprot.admin (configure).

Validation
- Build: PASS; Spotless: PASS.
- Tested: break/place blocked in zone unless creative or bypass permission; whitelisted blocks work.

Follow-ups
- Wire physics hardening events (TNT, pistons, fluid flow, enderman griefing, mob spawning).
- Add sphere shape support alongside cylinder.
- Integrate with future SpawnElytra system (detection radius coordination).